### PR TITLE
best 상품, 최신 상품 조회 쿼리의 반환 타입을 Page 에서 List로 변경

### DIFF
--- a/src/main/java/com/shoppingmall/repository/ProductRepository.java
+++ b/src/main/java/com/shoppingmall/repository/ProductRepository.java
@@ -25,10 +25,10 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     // 3. BatchSize로 해결 가능 (batch size만큼의 product를 미리 가져옴)
     // 1,2번은 paging 처리에서 문제 발생, 그래서 3번 선택
     @Query("select p from Product p")
-    Page<Product> findBestTop10Products(Pageable pageable);
+    List<Product> findBestTop10Products(Pageable pageable);
 
     @Query("select p from Product p")
-    Page<Product> findNewTop8Products(Pageable pageable);
+    List<Product> findNewTop8Products(Pageable pageable);
 
     Page<Product> findByLargeCatCdAndSmallCatCdOrderByCreatedDateDesc(String firstCatCd, String secondCatCd, Pageable pageable);
 

--- a/src/main/java/com/shoppingmall/service/ProductService.java
+++ b/src/main/java/com/shoppingmall/service/ProductService.java
@@ -142,7 +142,7 @@ public class ProductService {
 
     public List<ProductResponseDto.MainProductResponseDto> getBestProductList() {
         Pageable pageable = PageRequest.of(0, 10, new Sort(Sort.Direction.DESC, "purchaseCount"));
-        Page<Product> bestProducts = productRepository.findBestTop10Products(pageable);
+        List<Product> bestProducts = productRepository.findBestTop10Products(pageable);
 
         List<ProductResponseDto.MainProductResponseDto> bestProductResponseList = new ArrayList<>();
 
@@ -159,7 +159,7 @@ public class ProductService {
 
     public List<ProductResponseDto.MainProductResponseDto> getNewProductList() {
         Pageable pageable = PageRequest.of(0, 8, new Sort(Sort.Direction.DESC, "createdDate"));
-        Page<Product> newProducts = productRepository.findNewTop8Products(pageable);
+        List<Product> newProducts = productRepository.findNewTop8Products(pageable);
 
         List<ProductResponseDto.MainProductResponseDto> newProductResponseList = new ArrayList<>();
 


### PR DESCRIPTION
JPA에서는 Page 타입에 채울 정보를 얻기 위해 count 쿼리가 추가적으로 실행됨.
현재 상황에서 Page 타입의 정보가 필요 없으므로 반환 타입을 List 타입으로 변경하여 count 쿼리가 추가적으로 실행되지 않도록 함