### PR TITLE
manifest로 Main 메서드를 지정하지 않아 jar 실행 시 에러 발생 해결

### DIFF
--- a/app/api-server/build.gradle
+++ b/app/api-server/build.gradle
@@ -6,12 +6,10 @@ apply plugin: "com.ewerk.gradle.plugins.querydsl"
 
 version = '0.0.1-SNAPSHOT'
 
-bootJar{
-    enabled = false;
-}
-
 jar {
-    enabled = true;
+    manifest {
+        attributes 'Main-Class': 'com.shoppingmall.SpringbootWebserviceApplication'
+    }
 }
 
 dependencies {

--- a/app/batch-server/build.gradle
+++ b/app/batch-server/build.gradle
@@ -1,10 +1,9 @@
 version = '0.0.1-SNAPSHOT'
 
-bootJar{
-    enabled = false;
-}
 jar {
-    enabled = true;
+    manifest {
+        attributes 'Main-Class': 'com.quartzscheduler.BatchApplication'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
* app:api-server 모듈의 build.gradle 파일에 manifest 설정 추가
* app:batch-server 모듈의 build.gradle 파일에 manifest 설정 추가