### PR TITLE
app:batch-server 모듈에서 LazyInitialization Exception 예외 해결

### DIFF
--- a/app/batch-server/src/main/java/com/quartzscheduler/config/QuartzConfig.java
+++ b/app/batch-server/src/main/java/com/quartzscheduler/config/QuartzConfig.java
@@ -12,7 +12,7 @@ import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 
 import java.util.Objects;
 
-@EntityScan({"com.shoppingmall.domain.product", "com.shoppingmall.domain.productDisPrc"})
+@EntityScan({"com.shoppingmall.domain"})
 @EnableJpaRepositories(basePackages = {"com.shoppingmall.domain.product"})
 @RequiredArgsConstructor
 @Configuration


### PR DESCRIPTION
* JPA에서 같은 Transaction 내에서 엔티티 조회하지 않을 시 발생하는 LazyInitialization Exception 발생
* 하나의 job 부분을 Transactional로 처리하여 문제 해결 가능
* @Transactional이 작동하지 않아서 직접 TransactionManager를 만들어서 설정