### PR TITLE
sumProductPurchaseCountStep과  mergeProductPurchaseCountStep을 멀티쓰레드로 수행하도록 변경

### DIFF
--- a/app/product-purchase-count-batch/src/main/java/com/shoppingmall/ProductPurchaseCountBatchApplication.java
+++ b/app/product-purchase-count-batch/src/main/java/com/shoppingmall/ProductPurchaseCountBatchApplication.java
@@ -12,8 +12,8 @@ public class ProductPurchaseCountBatchApplication {
 
     private static final String APPLICATION_LOCATIONS = "spring.config.location="
             + "classpath:application.yml,"
-            + "/home/ec2-user/app/config/springboot-webservice/real-product-count-batch-application.yml";
-            //+ "C:\\config\\real-product-count-batch-application.yml";
+            + "/home/ec2-user/app/config/springboot-webservice/real-product-purchase-count-batch-application.yml";
+            //+ "C:\\config\\real-product-purchase-count-batch-application.yml";
 
     public static void main(String[] args) {
         new SpringApplicationBuilder(ProductPurchaseCountBatchApplication.class)

--- a/app/product-purchase-count-batch/src/main/resources/application.yml
+++ b/app/product-purchase-count-batch/src/main/resources/application.yml
@@ -7,6 +7,7 @@ server:
 
 logging.level.org.springframework.batch: DEBUG
 spring.batch.job.names: ${job.name:NONE}
+
 ---
 spring.profiles: local
 spring.profiles.include: local-social
@@ -32,6 +33,10 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
 
+chunkSize: 100
+pageSize: 100
+poolSize: 10
+
 ---
 spring.profiles: real
-spring.profiles.include: real-product-purchase-count
+spring.profiles.include: real-product-purchase-count-batch


### PR DESCRIPTION
* spring batch의 step은 멀티쓰레드를 이용한 병렬처리가 가능
* JpaPagingItemReader와 JpaItemWriter는 thread-safe한 환경을 지원
* 멀티 쓰레드로 각 Chunk들이 개별로 진행되다보니 Spring Batch의 큰 장점중 하나인 실패 지점에서 재시작하는 것은 불가능